### PR TITLE
Use harden-runner Action for all Workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - v*.*.*
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-and-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,16 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,12 @@ jobs:
     steps:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
       - uses: actions/checkout@v3
       - name: Install Poetry
         run: pipx install poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     branches: [ "*" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -12,6 +15,9 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v3
       - name: Install Poetry
         run: pipx install poetry


### PR DESCRIPTION
### Background

Relates to EPD-368

This PR adds StepSecurity's `harden-runners` Action to all of our Workflows. 

We'll run egress blocks for Workflows that can be validated within a PR and audits for the other Workflows. Once the latter run at least once, we can implement the recommendations in a follow-up PR.

### Changes

- Adds the `harden-runner` Action to all Workflows

### Testing

- Checks pass as expected