### PR TITLE
THREAT-332 Non-implemented LogTypes should not create rules

### DIFF
--- a/sigma/backends/panther/helpers/python_helper.py
+++ b/sigma/backends/panther/helpers/python_helper.py
@@ -118,7 +118,8 @@ class PythonHelper(BasePantherBackendHelper):
     def convert_condition_val_str(
         self, cond: ConditionValueExpression, state: ConversionState
     ) -> Any:
-        return f'"{cond.value.to_plain()}" in json.dumps(event.to_dict())'
+        value = self.prepare_cond_value(cond.value.to_plain())
+        return f'"{value}" in json.dumps(event.to_dict())'
 
     def _add_rule_suffix(self, query, file_name):
         return file_name

--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -3,6 +3,7 @@ from os import path
 from typing import Any
 
 import click
+from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 from sigma.processing.pipeline import ProcessingPipeline
 from sigma.processing.postprocessing import QueryPostprocessingTransformation
 from sigma.rule import SigmaLevel, SigmaRule
@@ -63,7 +64,7 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
 
         log_types = self._detect_log_types(rule)
         if len(log_types) == 0:
-            logging.error(f"Can't find any LogTypes")
+            raise SigmaFeatureNotSupportedByBackendError(f"Can't map any LogTypes")
         else:
             res["LogTypes"] = log_types
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,6 @@ def log_source():
 def rule(sigma_detection):
     return SigmaRule(
         "rule title",
-        logsource=SigmaLogSource(product="windows"),
+        logsource=SigmaLogSource(product="okta", service="okta"),
         detection=SigmaDetections({"query": sigma_detection}, condition=["query"]),
     )

--- a/tests/test_carbon_black_panther_pipeline.py
+++ b/tests/test_carbon_black_panther_pipeline.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import yaml
 from sigma.collection import SigmaCollection
@@ -8,7 +9,11 @@ from sigma.backends.panther import PantherBackend
 from sigma.pipelines.panther import carbon_black_panther_pipeline
 
 
-def test_basic():
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_basic(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "carbon_black_panther"}
+    )
     resolver = ProcessingPipelineResolver({"carbon_black_panther": carbon_black_panther_pipeline()})
     pipeline = resolver.resolve_pipeline("carbon_black_panther")
     backend = PantherBackend(pipeline)
@@ -37,6 +42,7 @@ def test_basic():
             "AnalysisType": "rule",
             "DisplayName": "Test Title",
             "Enabled": True,
+            "LogTypes": ["CarbonBlack.EndpointEvent"],
             "Tags": ["Sigma"],
             "Detection": [
                 {

--- a/tests/test_crowdstrike_panther_pipeline.py
+++ b/tests/test_crowdstrike_panther_pipeline.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import yaml
 from sigma.collection import SigmaCollection
@@ -8,7 +9,11 @@ from sigma.backends.panther import PantherBackend
 from sigma.pipelines.panther import crowdstrike_panther_pipeline
 
 
-def test_basic():
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_basic(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "crowdstrike_panther"}
+    )
     resolver = ProcessingPipelineResolver({"crowdstrike_panther": crowdstrike_panther_pipeline()})
     pipeline = resolver.resolve_pipeline("crowdstrike_panther")
     backend = PantherBackend(pipeline)
@@ -38,6 +43,7 @@ def test_basic():
             "AnalysisType": "rule",
             "DisplayName": "Test Title",
             "Enabled": True,
+            "LogTypes": ["Crowdstrike.FDREvent"],
             "Tags": ["Sigma"],
             "Detection": [
                 {

--- a/tests/test_gcp_audit_panther_pipeline.py
+++ b/tests/test_gcp_audit_panther_pipeline.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import pytest
 import yaml
@@ -22,8 +23,8 @@ def test_basic_sdyaml():
         id: {rule_id}
         description: description
         logsource:
-            category: gcp
-            product: gcp.audit
+            product: gcp
+            service: gcp.audit
         detection:
             sel:
                 Field1: "banana"
@@ -39,6 +40,7 @@ def test_basic_sdyaml():
             "AnalysisType": "rule",
             "DisplayName": "Test Title",
             "Enabled": True,
+            "LogTypes": ["GCP.AuditLog"],
             "Tags": ["Sigma"],
             "Detection": [
                 {
@@ -67,7 +69,11 @@ def test_basic_sdyaml():
     assert backend.convert(rule, output_format="sdyaml") == expected
 
 
-def test_with_keywords_python():
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_with_keywords_python(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "gcp_audit_panther"}
+    )
     resolver = ProcessingPipelineResolver({"gcp_audit_panther": gcp_audit_panther_pipeline()})
     pipeline = resolver.resolve_pipeline("gcp_audit_panther")
     backend = PantherBackend(pipeline)
@@ -79,8 +85,8 @@ def test_with_keywords_python():
         id: {rule_id}
         description: description
         logsource:
-            category: gcp
-            product: gcp.audit
+            product: gcp
+            service: gcp.audit
         detection:
             sel:
                 Field1: "banana"
@@ -115,6 +121,7 @@ def rule(event):
         ],
         "DisplayName": "Test Title",
         "Enabled": True,
+        "LogTypes": ["GCP.AuditLog"],
         "Tags": ["Sigma"],
     }
 

--- a/tests/test_panther_python_backend.py
+++ b/tests/test_panther_python_backend.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from sigma.collection import SigmaCollection
 
@@ -598,7 +600,11 @@ def test_1_of_selection(backend):
     assert result == expected_result
 
 
-def test_pipeline_simplification(backend):
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_pipeline_simplification(mock_click, backend):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "carbon_black_panther"}
+    )
     rule = """
     selection_img:
         - Image|endswith: '\\bcdedit.exe'

--- a/tests/test_panther_sdyaml_pipeline.py
+++ b/tests/test_panther_sdyaml_pipeline.py
@@ -10,8 +10,8 @@ def test_basic(sigma_backend):
         title: Test Title
         id: {uuid.uuid4()}
         logsource:
-            category: process_creation
-            product: windows
+            service: okta
+            product: okta
         detection:
             sel:
                 Field1: "banana"
@@ -26,6 +26,7 @@ def test_basic(sigma_backend):
             "Description": None,
             "Tags": ["Sigma"],
             "Enabled": True,
+            "LogTypes": ["Okta.SystemLog"],
             "Detection": [
                 {
                     "Condition": "Equals",

--- a/tests/test_replace_condition_ends_with.py
+++ b/tests/test_replace_condition_ends_with.py
@@ -13,8 +13,8 @@ class TestReplaceConditionEndsWith:
         title: Test Title
         id: {uuid.uuid4()}
         logsource:
-            category: process_creation
-            product: windows
+            service: okta
+            product: okta
         detection:
             sel:
                 Field: "banana"
@@ -30,6 +30,8 @@ class TestReplaceConditionEndsWith:
             Value: banana
         DisplayName: Test Title
         Enabled: true
+        LogTypes:
+          - Okta.SystemLog
         Tags:
           - Sigma
         """
@@ -47,8 +49,8 @@ class TestReplaceConditionEndsWith:
         title: Test Title
         id: {uuid.uuid4()}
         logsource:
-            category: process_creation
-            product: windows
+            service: okta
+            product: okta
         detection:
             sel:
                 Field:
@@ -70,6 +72,8 @@ class TestReplaceConditionEndsWith:
                 Value: apple
         DisplayName: Test Title
         Enabled: true
+        LogTypes:
+          - Okta.SystemLog
         Tags:
           - Sigma
         """
@@ -87,8 +91,8 @@ class TestReplaceConditionEndsWith:
         title: Test Title
         id: {uuid.uuid4()}
         logsource:
-            category: process_creation
-            product: windows
+            service: okta
+            product: okta
         detection:
             selection_img:
                 - Image|endswith: '\WMIC.exe'
@@ -112,19 +116,21 @@ class TestReplaceConditionEndsWith:
                 Value: wmic.exe
               - Any:
                 - Condition: EndsWith
-                  KeyPath: image
+                  KeyPath: Image
                   Value: \\WMIC.exe
               - Condition: Contains
-                KeyPath: command_line
+                KeyPath: CommandLine
                 Value: '/node:'
               - Condition: DoesNotContain
-                KeyPath: command_line
+                KeyPath: CommandLine
                 Value: '/node:127.0.0.1 '    
               - Condition: DoesNotContain
-                KeyPath: command_line
+                KeyPath: CommandLine
                 Value: '/node:localhost '   
         DisplayName: Test Title
         Enabled: true
+        LogTypes:
+          - Okta.SystemLog
         Tags:
          - Sigma
         """


### PR DESCRIPTION
Changes:
- Non-implemented LogTypes now raise `SigmaFeatureNotSupportedByBackendError` and do not create rules
- Small formatting error fix