### PR TITLE
THREAT-335 EDR pipelines should only convert implemented rule types

### DIFF
--- a/sigma/pipelines/panther/carbon_black_panther_pipeline.py
+++ b/sigma/pipelines/panther/carbon_black_panther_pipeline.py
@@ -4,6 +4,7 @@ from sigma.processing.transformations import (
     AddConditionTransformation,
     DropDetectionItemTransformation,
     FieldMappingTransformation,
+    RuleFailureTransformation,
 )
 
 from sigma.pipelines.panther.panther_pipeline import (
@@ -105,6 +106,32 @@ def carbon_black_panther_pipeline():
                     IncludeFieldCondition(
                         fields=["Protocol"],
                     )
+                ],
+            ),
+            ProcessingItem(
+                identifier="cb_fail_not_implemented_rule_type",
+                rule_condition_linking=any,
+                transformation=RuleFailureTransformation(
+                    "Rule type not currently supported by the CarbonBlack Sigma pipeline"
+                ),
+                rule_condition_negation=True,
+                rule_conditions=[
+                    logsource_windows(),
+                    logsource_mac(),
+                    logsource_linux(),
+                ],
+            ),
+            ProcessingItem(
+                identifier="cb_fail_not_implemented_rule_type",
+                rule_condition_linking=any,
+                transformation=RuleFailureTransformation(
+                    "Rule type not currently supported by the CarbonBlack Sigma pipeline"
+                ),
+                rule_condition_negation=True,
+                rule_conditions=[
+                    logsource_network_connection(),
+                    logsource_process_creation(),
+                    logsource_file_event(),
                 ],
             ),
         ],

--- a/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
+++ b/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
@@ -12,6 +12,7 @@ from sigma.processing.transformations import (
     DropDetectionItemTransformation,
     FieldMappingTransformation,
     ReplaceStringTransformation,
+    RuleFailureTransformation,
 )
 
 from sigma.pipelines.panther.panther_pipeline import (
@@ -19,6 +20,7 @@ from sigma.pipelines.panther.panther_pipeline import (
     logsource_linux,
     logsource_mac,
     logsource_network_connection,
+    logsource_process_creation,
     logsource_windows,
 )
 from sigma.pipelines.panther.processing import RuleIContainsDetectionItemCondition
@@ -274,6 +276,32 @@ def crowdstrike_panther_pipeline():
                     IncludeFieldCondition(
                         fields=["Protocol"],
                     )
+                ],
+            ),
+            ProcessingItem(
+                identifier="cb_fail_not_implemented_rule_type",
+                rule_condition_linking=any,
+                transformation=RuleFailureTransformation(
+                    "Rule type not currently supported by the CrowdStrike Sigma pipeline"
+                ),
+                rule_condition_negation=True,
+                rule_conditions=[
+                    logsource_windows(),
+                    logsource_mac(),
+                    logsource_linux(),
+                ],
+            ),
+            ProcessingItem(
+                identifier="cb_fail_not_implemented_rule_type",
+                rule_condition_linking=any,
+                transformation=RuleFailureTransformation(
+                    "Rule type not currently supported by the CrowdStrike Sigma pipeline"
+                ),
+                rule_condition_negation=True,
+                rule_conditions=[
+                    logsource_network_connection(),
+                    logsource_process_creation(),
+                    logsource_file_event(),
                 ],
             ),
         ],

--- a/tests/test_panther_python_backend.py
+++ b/tests/test_panther_python_backend.py
@@ -22,7 +22,8 @@ def sigma_query(detection):
     return f"""
 title: Test
 logsource:
-    product: test
+    category: process_creation
+    product: macos
 detection:
     {detection}
 """
@@ -617,6 +618,8 @@ def test_pipeline_simplification(mock_click, backend):
     expected_result = """def rule(event):
     if all(
         [
+            event.deep_get("type", default="") == "endpoint.event.procstart",
+            event.deep_get("device_os", default="") == "MAC",
             event.deep_get("process_path", default="").endswith("\\\\bcdedit.exe"),
             "set" in event.deep_get("target_cmdline", default=""),
         ]


### PR DESCRIPTION
EDR pipelines should only convert sigma product/service combinations that are implemented. Today that is **product**: `macos`, `linux`, `windows` and **category**: `file_event`, `process_creation`, `network_connection`