### PR TITLE
Add pipelines for Windows Audit and Log Sources

### DIFF
--- a/sigma/backends/panther/helpers/base.py
+++ b/sigma/backends/panther/helpers/base.py
@@ -80,6 +80,11 @@ class BasePantherBackendHelper(ABC):
             prefix = "cs_"
         if "sentinelone_panther" in enabled_pipelines:
             prefix = "s1_"
+        if (
+            "windows_logsource_panther" in enabled_pipelines
+            or "windows_audit_panther" in enabled_pipelines
+        ):
+            prefix = "win_"
 
         if prefix:
             file_name = prefix + file_name

--- a/sigma/pipelines/panther/__init__.py
+++ b/sigma/pipelines/panther/__init__.py
@@ -2,9 +2,7 @@ from .carbon_black_panther_pipeline import carbon_black_panther_pipeline
 from .crowdstrike_panther_pipeline import crowdstrike_panther_pipeline
 from .panther_pipeline import panther_pipeline
 from .sentinelone_panther_pipeline import sentinelone_panther_pipeline
-from .windows import windows_audit_pipeline, windows_logsource_pipeline
-
-pipelines = {
-    "windows-logsources": windows_logsource_pipeline,
-    "windows-audit": windows_audit_pipeline,
-}
+from .windows_panther_pipeline import (
+    windows_audit_panther_pipeline,
+    windows_logsource_panther_pipeline,
+)

--- a/sigma/pipelines/panther/__init__.py
+++ b/sigma/pipelines/panther/__init__.py
@@ -2,3 +2,9 @@ from .carbon_black_panther_pipeline import carbon_black_panther_pipeline
 from .crowdstrike_panther_pipeline import crowdstrike_panther_pipeline
 from .panther_pipeline import panther_pipeline
 from .sentinelone_panther_pipeline import sentinelone_panther_pipeline
+from .windows import windows_audit_pipeline, windows_logsource_pipeline
+
+pipelines = {
+    "windows-logsources": windows_logsource_pipeline,
+    "windows-audit": windows_audit_pipeline,
+}

--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -96,8 +96,8 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
 
             if any(
                 [
-                    "windows-audit" in cli_context.params["pipeline"],
-                    "windows-logsources" in cli_context.params["pipeline"],
+                    "windows_audit_panther" in cli_context.params["pipeline"],
+                    "windows_logsource_panther" in cli_context.params["pipeline"],
                 ]
             ):
                 log_types.append("Windows.EventLogs")

--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -1,4 +1,3 @@
-import logging
 from os import path
 from typing import Any
 
@@ -64,7 +63,7 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
 
         log_types = self._detect_log_types(rule)
         if len(log_types) == 0:
-            raise SigmaFeatureNotSupportedByBackendError(f"Can't map any LogTypes")
+            raise SigmaFeatureNotSupportedByBackendError("Can't map any LogTypes")
         else:
             res["LogTypes"] = log_types
 
@@ -94,4 +93,12 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
 
             if "sentinelone_panther" in cli_context.params["pipeline"]:
                 log_types.append("SentinelOne.DeepVisibilityV2")
+
+            if any(
+                [
+                    "windows-audit" in cli_context.params["pipeline"],
+                    "windows-logsources" in cli_context.params["pipeline"],
+                ]
+            ):
+                log_types.append("Windows.EventLogs")
         return log_types

--- a/sigma/pipelines/panther/windows.py
+++ b/sigma/pipelines/panther/windows.py
@@ -1,0 +1,194 @@
+from ast import Dict
+
+from sigma.pipelines.common import generate_windows_logsource_items, logsource_windows
+from sigma.processing.conditions import ExcludeFieldCondition, LogsourceCondition
+from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline, QueryPostprocessingItem
+from sigma.processing.transformations import (
+    AddConditionTransformation,
+    AddFieldnamePrefixTransformation,
+    ChangeLogsourceTransformation,
+    FieldMappingTransformation,
+    RuleFailureTransformation,
+)
+
+from sigma.pipelines.panther.sdyaml_transformation import SdYamlTransformation
+
+windows_generic_category_channel_mapping = {  # map generic windows log sources to windows channel
+    "ps_module": {"service": "powershell", "EventID": 4103},
+    "ps_script": {"service": "powershell", "EventID": 4104},
+    "ps_classic_start": {"service": "powershell-classic", "EventID": 400},
+    "ps_classic_provider_start": {"service": "powershell-classic", "EventID": 600},
+    "ps_classic_script": {"service": "powershell-classic", "EventID": 800},
+}
+
+generic_logsource_to_windows_audit_event_mapping: Dict = (
+    {  # map generic Sigma log sources to Windows audit log events for the windows_audit_pipeline
+        "process_creation": {
+            "EventID": 4688,
+        },
+        "registry_event": {
+            "EventID": 4657,
+            "OperationType": [
+                "New registry value created",
+                "Existing registry value modified",
+            ],
+        },
+        "registry_set": {
+            "EventID": 4657,
+            "OperationType": "Existing registry value modified",
+        },
+        "registry_add": {
+            "EventID": 4657,
+            "OperationType": "New registry value created",
+        },
+    }
+)
+
+
+panther_windows_prefix = ProcessingItem(
+    transformation=AddFieldnamePrefixTransformation(prefix="ExtraEventData."),
+    field_name_conditions=[
+        ExcludeFieldCondition(
+            fields=[
+                "ProcessID",
+                "ThreadID",
+                "TimeCreated",
+                "EventID",
+                "ProviderName",
+                "ProviderGuid",
+                "Qualifiers",
+                "Version",
+                "Level",
+                "Task",
+                "Opcode",
+                "Keywords",
+                "EventRecordID",
+                "ActivityID",
+                "RelatedActivityID",
+                "Channel",
+                "Computer",
+                "UserID",
+                "Message",
+                "MessageTitle",
+            ]
+        ),
+    ],
+)
+
+
+def windows_logsource_pipeline() -> ProcessingPipeline:
+    the_service = generate_windows_logsource_items(
+        cond_field_template="Channel",
+        cond_value_template="{source}",
+    )
+
+    the_category = [
+        processing_item
+        for category_name, info in windows_generic_category_channel_mapping.items()
+        for processing_item in (
+            ProcessingItem(
+                identifier=f"windows_{category_name}_channel",
+                transformation=AddConditionTransformation(
+                    {
+                        "EventID": info["EventID"],
+                    }
+                ),
+                rule_conditions=[LogsourceCondition(category=category_name, product="windows")],
+            ),
+            ProcessingItem(
+                identifier="windows_{category_name}_logsource",
+                transformation=ChangeLogsourceTransformation(
+                    product="windows", service=info["service"], category=category_name
+                ),
+                rule_conditions=[LogsourceCondition(category=category_name, product="windows")],
+            ),
+        )
+    ] + [
+        panther_windows_prefix,
+        ProcessingItem(
+            identifier="windows_fail_not_implemented_rule_type",
+            rule_condition_linking=any,
+            transformation=RuleFailureTransformation(
+                "Rule type not currently supported by the Windows Log Source pipeline"
+            ),
+            rule_condition_negation=True,
+            rule_conditions=[
+                LogsourceCondition(category=category_name, product="windows")
+                for category_name in windows_generic_category_channel_mapping.keys()
+            ]
+            + [
+                LogsourceCondition(service=info["service"])
+                for info in windows_generic_category_channel_mapping.values()
+            ],
+        ),
+    ]
+
+    return ProcessingPipeline(
+        name="Add Channel condition for Windows log sources",
+        priority=10,
+        items=the_category + the_service,
+        postprocessing_items=[QueryPostprocessingItem(transformation=SdYamlTransformation())],
+    )
+
+
+def windows_audit_pipeline() -> ProcessingPipeline:
+    return ProcessingPipeline(
+        name="Map generic log sources to Windows audit logs",
+        priority=10,
+        items=[
+            processing_item
+            for logsource, conditions in generic_logsource_to_windows_audit_event_mapping.items()
+            for processing_item in (
+                ProcessingItem(
+                    identifier=f"windows_{logsource}_condition",
+                    transformation=AddConditionTransformation(conditions),
+                    rule_conditions=[
+                        LogsourceCondition(
+                            category=logsource,
+                            product="windows",
+                        )
+                    ],
+                ),
+                ProcessingItem(
+                    identifier=f"windows_{logsource}_logsource",
+                    transformation=ChangeLogsourceTransformation(
+                        product="windows",
+                        service="security",
+                    ),
+                    rule_conditions=[
+                        LogsourceCondition(
+                            category=logsource,
+                            product="windows",
+                        )
+                    ],
+                ),
+            )
+        ]
+        + [
+            ProcessingItem(
+                identifier="windows_audit_fieldmappings",
+                transformation=FieldMappingTransformation(
+                    {
+                        "Image": "NewProcessName",
+                        "ParentImage": "ParentProcessName",
+                        "Details": "NewValue",
+                        "LogonId": "SubjectLogonId",
+                    }
+                ),
+                rule_conditions=[
+                    logsource_windows("security"),
+                ],
+            ),
+            panther_windows_prefix,
+            ProcessingItem(
+                identifier="windows_fail_not_implemented_rule_type",
+                rule_condition_linking=any,
+                transformation=RuleFailureTransformation(
+                    "Rule type not currently supported by the Windows Audit pipeline"
+                ),
+                rule_condition_negation=True,
+                rule_conditions=[logsource_windows("security")],
+            ),
+        ],
+        postprocessing_items=[QueryPostprocessingItem(transformation=SdYamlTransformation())],
+    )

--- a/sigma/pipelines/panther/windows_panther_pipeline.py
+++ b/sigma/pipelines/panther/windows_panther_pipeline.py
@@ -76,7 +76,7 @@ panther_windows_prefix = ProcessingItem(
 )
 
 
-def windows_logsource_pipeline() -> ProcessingPipeline:
+def windows_logsource_panther_pipeline() -> ProcessingPipeline:
     the_service = generate_windows_logsource_items(
         cond_field_template="Channel",
         cond_value_template="{source}",
@@ -131,7 +131,7 @@ def windows_logsource_pipeline() -> ProcessingPipeline:
     )
 
 
-def windows_audit_pipeline() -> ProcessingPipeline:
+def windows_audit_panther_pipeline() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Map generic log sources to Windows audit logs",
         priority=10,

--- a/tests/test_replace_condition_ends_with.py
+++ b/tests/test_replace_condition_ends_with.py
@@ -21,7 +21,7 @@ class TestReplaceConditionEndsWith:
             condition: sel
         """
 
-        expected = f"""
+        expected = """
         AnalysisType: rule
         Description: null
         Detection:
@@ -59,7 +59,7 @@ class TestReplaceConditionEndsWith:
             condition: sel
         """
 
-        expected = f"""
+        expected = """
         AnalysisType: rule
         Description: null
         Detection:
@@ -106,7 +106,7 @@ class TestReplaceConditionEndsWith:
             condition: all of selection_* and not 1 of filter_*
         """
 
-        expected = f"""
+        expected = """
         AnalysisType: rule
         Description: null
         Detection:

--- a/tests/test_windows_panther_pipeline.py
+++ b/tests/test_windows_panther_pipeline.py
@@ -1,0 +1,270 @@
+import uuid
+from unittest import mock
+
+import yaml
+from sigma.collection import SigmaCollection
+from sigma.processing.resolver import ProcessingPipelineResolver
+
+from sigma.backends.panther import PantherBackend
+from sigma.pipelines.panther import (
+    windows_audit_panther_pipeline,
+    windows_logsource_panther_pipeline,
+)
+
+
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_windows_audit_basic_sdyaml(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "windows_audit_panther"}
+    )
+    resolver = ProcessingPipelineResolver(
+        {"windows_audit_panther": windows_audit_panther_pipeline()}
+    )
+    pipeline = resolver.resolve_pipeline("windows_audit_panther")
+    backend = PantherBackend(pipeline)
+
+    rule_id = uuid.uuid4()
+    rule = SigmaCollection.from_yaml(
+        f"""
+        title: Test Title
+        id: {rule_id}
+        description: description
+        logsource:
+            category: process_creation
+            product: windows
+        detection:
+            sel:
+                Details: "banana"
+                CommandLine: "cmdline_test"
+                Image: "test_image"
+            condition: sel
+    """
+    )
+
+    expected = yaml.dump(
+        {
+            "Description": "description",
+            "AnalysisType": "rule",
+            "DisplayName": "Test Title",
+            "Enabled": True,
+            "LogTypes": ["Windows.EventLogs"],
+            "Tags": ["Sigma"],
+            "Detection": [
+                {
+                    "All": [
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "EventID",
+                            "Value": 4688,
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ExtraEventData.NewValue",
+                            "Value": "banana",
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ExtraEventData.CommandLine",
+                            "Value": "cmdline_test",
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ExtraEventData.NewProcessName",
+                            "Value": "test_image",
+                        },
+                    ]
+                }
+            ],
+        }
+    )
+
+    assert backend.convert(rule, output_format="sdyaml") == expected
+
+
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_windows_audit_basic_python(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "windows_audit_panther"}
+    )
+    resolver = ProcessingPipelineResolver(
+        {"windows_audit_panther": windows_audit_panther_pipeline()}
+    )
+    pipeline = resolver.resolve_pipeline("windows_audit_panther")
+    backend = PantherBackend(pipeline)
+
+    rule_id = uuid.uuid4()
+    rule = SigmaCollection.from_yaml(
+        f"""
+            title: Test Title
+            id: {rule_id}
+            description: description
+            logsource:
+                category: process_creation
+                product: windows
+            detection:
+                sel:
+                    Details: "banana"
+                    CommandLine: "cmdline_test"
+                    Image: "test_image"
+                condition: sel
+        """
+    )
+
+    expected = {
+        "Description": "description",
+        "AnalysisType": "rule",
+        "DisplayName": "Test Title",
+        "Enabled": True,
+        "LogTypes": ["Windows.EventLogs"],
+        "Tags": ["Sigma"],
+        "Detection": [
+            """def rule(event):
+    if all(
+        [
+            event.deep_get("EventID", default="") == 4688,
+            event.deep_get("ExtraEventData", "NewValue", default="") == "banana",
+            event.deep_get("ExtraEventData", "CommandLine", default="") == "cmdline_test",
+            event.deep_get("ExtraEventData", "NewProcessName", default="") == "test_image",
+        ]
+    ):
+        return True
+    return False
+"""
+        ],
+    }
+
+    assert backend.convert(rule_collection=rule, output_format="python") == expected
+
+
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_windows_logsource_basic_sdyaml(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "windows_logsource_panther"}
+    )
+    resolver = ProcessingPipelineResolver(
+        {"windows_logsource_panther": windows_logsource_panther_pipeline()}
+    )
+    pipeline = resolver.resolve_pipeline("windows_logsource_panther")
+    backend = PantherBackend(pipeline)
+
+    rule_id = uuid.uuid4()
+    rule = SigmaCollection.from_yaml(
+        f"""
+        title: Test Title
+        id: {rule_id}
+        description: description
+        logsource:
+            category: ps_script
+            product: windows
+        detection:
+            sel:
+                Details: "banana"
+                CommandLine: "cmdline_test"
+                Image: "test_image"
+            condition: sel
+    """
+    )
+
+    expected = yaml.dump(
+        {
+            "Description": "description",
+            "AnalysisType": "rule",
+            "DisplayName": "Test Title",
+            "Enabled": True,
+            "LogTypes": ["Windows.EventLogs"],
+            "Tags": ["Sigma"],
+            "Detection": [
+                {
+                    "All": [
+                        {
+                            "Condition": "IsIn",
+                            "KeyPath": "Channel",
+                            "Values": [
+                                "Microsoft-Windows-PowerShell/Operational",
+                                "PowerShellCore/Operational",
+                            ],
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "EventID",
+                            "Value": 4104,
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ExtraEventData.Details",
+                            "Value": "banana",
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ExtraEventData.CommandLine",
+                            "Value": "cmdline_test",
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ExtraEventData.Image",
+                            "Value": "test_image",
+                        },
+                    ]
+                }
+            ],
+        }
+    )
+
+    assert backend.convert(rule, output_format="sdyaml") == expected
+
+
+@mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")
+def test_windows_logsource_basic_python(mock_click):
+    mock_click.get_current_context.return_value = mock.MagicMock(
+        params={"pipeline": "windows_logsource_panther"}
+    )
+    resolver = ProcessingPipelineResolver(
+        {"windows_logsource_panther": windows_logsource_panther_pipeline()}
+    )
+    pipeline = resolver.resolve_pipeline("windows_logsource_panther")
+    backend = PantherBackend(pipeline)
+
+    rule_id = uuid.uuid4()
+    rule = SigmaCollection.from_yaml(
+        f"""
+            title: Test Title
+            id: {rule_id}
+            description: description
+            logsource:
+                category: ps_script
+                product: windows
+            detection:
+                sel:
+                    Details: "banana"
+                    CommandLine: "cmdline_test"
+                    Image: "test_image"
+                condition: sel
+        """
+    )
+
+    expected = {
+        "Description": "description",
+        "AnalysisType": "rule",
+        "DisplayName": "Test Title",
+        "Enabled": True,
+        "LogTypes": ["Windows.EventLogs"],
+        "Tags": ["Sigma"],
+        "Detection": [
+            """def rule(event):
+    if all(
+        [
+            event.deep_get("Channel", default="")
+            in ["Microsoft-Windows-PowerShell/Operational", "PowerShellCore/Operational"],
+            event.deep_get("EventID", default="") == 4104,
+            event.deep_get("ExtraEventData", "Details", default="") == "banana",
+            event.deep_get("ExtraEventData", "CommandLine", default="") == "cmdline_test",
+            event.deep_get("ExtraEventData", "Image", default="") == "test_image",
+        ]
+    ):
+        return True
+    return False
+"""
+        ],
+    }
+
+    assert backend.convert(rule_collection=rule, output_format="python") == expected


### PR DESCRIPTION
Adds 2 new pipelines for windows-audit and windows-logsources, based on[ pySigma-pipeline-windows](https://github.com/SigmaHQ/pySigma-pipeline-windows), modified for Panther schemas.