### PR TITLE
Python format default

### DIFF
--- a/sigma/backends/panther/panther_backend.py
+++ b/sigma/backends/panther/panther_backend.py
@@ -29,14 +29,14 @@ from sigma.pipelines.panther import panther_pipeline
 
 class PantherBackend(Backend):
     # `output_dir` param should be used for saving each rule into separate file
-    # `sigma convert -t panther_sdyaml -O output_dir=/tmp/directory`
+    # `sigma convert -t panther -O output_dir=/tmp/directory`
     output_dir: Optional[str] = None
 
-    name: ClassVar[str] = "panther sdyaml backend"
+    name: ClassVar[str] = "panther backend"
 
-    default_format: ClassVar[str] = "sdyaml"
+    default_format: ClassVar[str] = "python"
     formats = {
-        "default": "sdyaml",
+        "default": "python",
         "sdyaml": "sdyaml",
         "python": "python",
     }
@@ -47,7 +47,7 @@ class PantherBackend(Backend):
     }
 
     format_helpers = {
-        "default": SDYAMLHelper(),
+        "default": PythonHelper(),
         "sdyaml": SDYAMLHelper(),
         "python": PythonHelper(),
     }
@@ -292,7 +292,7 @@ class PantherBackend(Backend):
         )
 
     def finalize_output_default(self, queries: List[Any]) -> Any:
-        return self.finalize_output_sdyaml(queries)
+        return self.finalize_output_python(queries)
 
     def finalize_output_sdyaml(self, queries):
         if self.output_dir:

--- a/tests/test_carbon_black_panther_pipeline.py
+++ b/tests/test_carbon_black_panther_pipeline.py
@@ -80,7 +80,7 @@ def test_basic(mock_click):
         }
     )
 
-    assert backend.convert(rule) == expected
+    assert backend.convert(rule, output_format="sdyaml") == expected
 
 
 @mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")

--- a/tests/test_crowdstrike_panther_pipeline.py
+++ b/tests/test_crowdstrike_panther_pipeline.py
@@ -90,7 +90,7 @@ def test_basic(mock_click):
         }
     )
 
-    assert backend.convert(rule) == expected
+    assert backend.convert(rule, output_format="sdyaml") == expected
 
 
 @mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")

--- a/tests/test_panther_sdyaml_pipeline.py
+++ b/tests/test_panther_sdyaml_pipeline.py
@@ -37,4 +37,4 @@ def test_basic(sigma_backend):
         }
     )
 
-    assert sigma_backend.convert(rule) == expected
+    assert sigma_backend.convert(rule, output_format="sdyaml") == expected

--- a/tests/test_replace_condition_ends_with.py
+++ b/tests/test_replace_condition_ends_with.py
@@ -41,7 +41,7 @@ class TestReplaceConditionEndsWith:
         rule = SigmaRule.from_yaml(raw_rule)
         transformation.apply(pipeline, rule)
 
-        res = sigma_backend.convert(SigmaCollection(rules=[rule]))
+        res = sigma_backend.convert(SigmaCollection(rules=[rule]), output_format="sdyaml")
         assert yaml.safe_load(res) == yaml.safe_load(expected)
 
     def test_with_multiple_values(self, pipeline, sigma_backend):
@@ -83,7 +83,7 @@ class TestReplaceConditionEndsWith:
         rule = SigmaRule.from_yaml(raw_rule)
         transformation.apply(pipeline, rule)
 
-        res = sigma_backend.convert(SigmaCollection(rules=[rule]))
+        res = sigma_backend.convert(SigmaCollection(rules=[rule]), output_format="sdyaml")
         assert yaml.safe_load(res) == yaml.safe_load(expected)
 
     def test_with_nested_detections(self, pipeline, sigma_backend):
@@ -140,5 +140,5 @@ class TestReplaceConditionEndsWith:
         rule = SigmaRule.from_yaml(raw_rule)
         transformation.apply(pipeline, rule)
 
-        res = sigma_backend.convert(SigmaCollection(rules=[rule]))
+        res = sigma_backend.convert(SigmaCollection(rules=[rule]), output_format="sdyaml")
         assert yaml.safe_load(res) == yaml.safe_load(expected)

--- a/tests/test_sentinelone_panther_pipeline.py
+++ b/tests/test_sentinelone_panther_pipeline.py
@@ -78,7 +78,7 @@ def test_basic_sdyaml(mock_click):
         }
     )
 
-    assert backend.convert(rule) == expected
+    assert backend.convert(rule, output_format="sdyaml") == expected
 
 
 @mock.patch("sigma.pipelines.panther.sdyaml_transformation.click")


### PR DESCRIPTION
Makes `-f python` the default output format, to match the [docs](https://docs.panther.com/panther-developer-workflows/converting-sigma-rules#using-the-tool)