### PR TITLE
finalize_query_default

### DIFF
--- a/sigma/backends/panther/panther_backend.py
+++ b/sigma/backends/panther/panther_backend.py
@@ -349,6 +349,9 @@ class PantherBackend(Backend):
             return queries[0]
         return queries
 
+    def finalize_query_default(self, rule: SigmaRule, query: Any, index: int, state: ConversionState):
+        return self.finalize_query_python(rule, query, index, state)
+
     def finalize_query_sdyaml(
         self, rule: SigmaRule, query: Any, index: int, state: ConversionState
     ):

--- a/sigma/backends/panther/panther_backend.py
+++ b/sigma/backends/panther/panther_backend.py
@@ -349,7 +349,9 @@ class PantherBackend(Backend):
             return queries[0]
         return queries
 
-    def finalize_query_default(self, rule: SigmaRule, query: Any, index: int, state: ConversionState):
+    def finalize_query_default(
+        self, rule: SigmaRule, query: Any, index: int, state: ConversionState
+    ):
         return self.finalize_query_python(rule, query, index, state)
 
     def finalize_query_sdyaml(


### PR DESCRIPTION
Adds finalize_query_default to properly format python rules when no format flag is supplied.