### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @panther-labs/threat-researcher
+* @panther-labs/threat-research

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @panther-labs/threat-researcher


### PR DESCRIPTION
Adds codeowners to the repository in order for the team to be autoassigned to PR reviews.