### PR TITLE
Resolve codeql issues

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  contents: write
+
 jobs:
   tag-on-merge:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -3,6 +3,9 @@ name: Build, Test, Publish Github and PyPI Releases
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   publish_github_release_and_pypi:
     strategy:


### PR DESCRIPTION
Description
If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

Recommendations
Add the permissions key to the job or the root of workflow (in this case it is applied to all jobs in the workflow that do not have their own permissions key) and assign the least privileges required to complete the task:

name: "My workflow"
permissions:
  contents: read
  pull-requests: write
or

jobs:
  my-job:
    permissions:
      contents: read
      pull-requests: write
References
[Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs)