### PR TITLE
Fix: MITRE ATT&CK Tactic Mapping

### DIFF
--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -1,5 +1,6 @@
 from os import path
 from typing import Any
+import warnings
 
 import click
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
@@ -107,7 +108,8 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
             if tactics:
                 res["Reports"] = {"MITRE ATT&CK": [f"{tac}:{teq}" for tac in tactics for teq in techniques]}
             else:
-                res["Reports"] = {"MITRE ATT&CK": techniques}
+                rule_id = dict(res).get("RuleID", "")
+                warnings.warn(f"Unable to determine MITRE Technique; skipping MITRE Mapping for rule{' ' + rule_id if rule_id else ''}")
 
         return res
 

--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -17,6 +17,23 @@ SEVERITY_MAPPING = {
     SigmaLevel.CRITICAL: "Critical",
 }
 
+MITRE_TAGS_MAP = {
+    "initial-access": "TA0001",
+    "execution": "TA0002",
+    "persistence": "TA0003",
+    "privilege-escalation": "TA0004",
+    "defense-evasion": "TA0005",
+    "credential-access": "TA0006",
+    "discovery": "TA0007",
+    "lateral-movement": "TA0008",
+    "collection": "TA0009",
+    "exfiltration": "TA0010",
+    "command-and-control": "TA0011",
+    "impact": "TA0040",
+    "resource-development": "TA0042",
+    "reconnaissance": "TA0043",
+}
+
 
 class SdYamlTransformation(QueryPostprocessingTransformation):
     identifier = "SDYaml"
@@ -76,15 +93,25 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
                 res["Detection"] = [f"panther_logs.public.{LOG_TYPES_MAP[log_type]}\n{query}"]
 
         if rule.tags:
-            mittre_tags = []
+            tactics = []
+            techniques = []
             for tag in rule.tags:
-                if tag.namespace == "attack" and tag.name.startswith("t"):
-                    mittre_tags.append(tag.name.upper())
-            res["Reports"] = {"MITRE ATT&CK": mittre_tags}
+                if tag.namespace == "attack":
+                    if not tag.name[1].isdigit():
+                        if tag.name in MITRE_TAGS_MAP:
+                            tactics.append(MITRE_TAGS_MAP[tag.name])
+                        else:
+                            raise SigmaFeatureNotSupportedByBackendError(f"MITRE ATT&CK tactic {tag.name} not found recognized")
+                    else:
+                        techniques.append(tag.name.upper())
+            if tactics:
+                res["Reports"] = {"MITRE ATT&CK": [f"{tac}:{teq}" for tac in tactics for teq in techniques]}
+            else:
+                res["Reports"] = {"MITRE ATT&CK": techniques}
 
         return res
 
-    def _detect_log_types(self, rule: SigmaRule) -> [str]:
+    def _detect_log_types(self, rule: SigmaRule) -> list[str]:
         log_types = []
 
         mapped_log_type = self._logsources_map.get((rule.logsource.product, rule.logsource.service))

--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -1,6 +1,6 @@
+import warnings
 from os import path
 from typing import Any
-import warnings
 
 import click
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
@@ -102,14 +102,20 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
                         if tag.name in MITRE_TAGS_MAP:
                             tactics.append(MITRE_TAGS_MAP[tag.name])
                         else:
-                            raise SigmaFeatureNotSupportedByBackendError(f"MITRE ATT&CK tactic {tag.name} not found recognized")
+                            raise SigmaFeatureNotSupportedByBackendError(
+                                f"MITRE ATT&CK tactic {tag.name} not found recognized"
+                            )
                     else:
                         techniques.append(tag.name.upper())
             if tactics:
-                res["Reports"] = {"MITRE ATT&CK": [f"{tac}:{teq}" for tac in tactics for teq in techniques]}
+                res["Reports"] = {
+                    "MITRE ATT&CK": [f"{tac}:{teq}" for tac in tactics for teq in techniques]
+                }
             else:
                 rule_id = dict(res).get("RuleID", "")
-                warnings.warn(f"Unable to determine MITRE Technique; skipping MITRE Mapping for rule{' ' + rule_id if rule_id else ''}")
+                warnings.warn(
+                    f"Unable to determine MITRE Technique; skipping MITRE Mapping for rule{' ' + rule_id if rule_id else ''}"
+                )
 
         return res
 

--- a/tests/test_replace_condition_ends_with.py
+++ b/tests/test_replace_condition_ends_with.py
@@ -95,7 +95,7 @@ class TestReplaceConditionEndsWith:
             product: okta
         detection:
             selection_img:
-                - Image|endswith: '\WMIC.exe'
+                - Image|endswith: '\\WMIC.exe'
                 - OriginalFileName: 'wmic.exe'
             selection_cli:
                 CommandLine|contains: '/node:'

--- a/tests/test_sdyaml_transformation.py
+++ b/tests/test_sdyaml_transformation.py
@@ -144,9 +144,9 @@ class TestSdYamlTransformation:
             transformation.apply(pipeline, rule, "")
         assert err.value.args[0] == "MITRE ATT&CK tactic fake-tactic-name not found recognized"
 
-    def test_mitre_tags_technique(self, pipeline, rule):
+    def test_mitre_tags_no_tactic(self, pipeline, rule):
         transformation = SdYamlTransformation()
-        res = transformation.apply(pipeline, rule, "")
+        rule.tags = [SigmaRuleTag("attack", "t1001")]
+        with pytest.warns():
+            res = transformation.apply(pipeline, rule, "")
         assert "Reports" not in res
-
-        rule.tags = [SigmaRuleTag("attack", "t1001"), SigmaRuleTag("attack", "T1002")]


### PR DESCRIPTION
### Summary

A customer reported that rules converted using our plugin don't pass the `check-mitre` script in panther-analysis because the MITRE report mappings only include the technique and not the tactic. This PR adds some code to either infer the tactic where possible, or exclude the mapping (and raise a warning) where not.

Sigma rules appear to have the MITRE tactic specified in a separate tag, in the form `attack.tactic-name`. The logic I've added extracts the tactic name and compares it to a hard-coded list of MITRE enterprise tactics. This may not be ideal if:

* this convention of specifying the tactics by name is not a Sigma requirement
* there are other MITRE tactics which should be supported or are not in that list

I'd like to have a dynamic way to lookup tactic names and get the IDs, but there doesn't seem to be one so far.

**INTERNAL**: See [ASK-2297](https://panther-labs.atlassian.net/browse/ASK-2297) for additional context on this issue.

### Changes

* added warning to the mitre conversion code
* added logic to look for an appropriate mitre tactic based on the available tags
* added an error to be raised if an unknown mitre tactic is present

### Testing

In addition to the current MITRE test (that it works), I added 2 other tests: one to ensure an error is raised for an invalid tactic name, and another to ensure that a warning is raised, and the resultant rule has no MITRE mappings, when the source rule has no tactic specified at all.